### PR TITLE
Add support for Demagnetize mod and conveyors

### DIFF
--- a/src/main/java/codechicken/nei/handler/MagnetModeHandler.java
+++ b/src/main/java/codechicken/nei/handler/MagnetModeHandler.java
@@ -74,6 +74,9 @@ public class MagnetModeHandler {
             if (item.isDead) {
                 iterator.remove();
             }
+            if (item.getEntityData().getBoolean("PreventRemoteMovement")) {
+                continue;
+            }
             if (!NEIClientUtils.canItemFitInInventory(player, item.getItem())) {
                 continue;
             }
@@ -140,6 +143,9 @@ public class MagnetModeHandler {
                     continue;
                 }
                 if (!NEIServerUtils.canItemFitInInventory(player, item.getItem())) {
+                    continue;
+                }
+                if (item.getEntityData().getBoolean("PreventRemoteMovement")) {
                     continue;
                 }
                 if (save.magneticItems.add(item)) {


### PR DESCRIPTION
Immersive Engineering's conveyors (and [my Demagnetize mod](https://minecraft.curseforge.com/projects/demagnetize)) add the PreventRemoteMovement NBT tag to the item. This prevents them from being picked up by magnets, such as NEI's magnet button.
